### PR TITLE
Add option `g:BufSelectFloatWinHighlight` to update winhl for Float Window

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,17 @@ The colors used in **BufSelect** were picked to work in both dark and light back
 * `BufSelectUnsaved` - unsaved buffers, indicated by a `+`
 * `BufSelectHelp` - the question mark in `? for help`
 * `BufSelectKeys` - mapped keys in the help text
+
+Float window highlight can be customized with `g:BufSelectFloatWinHighlight`. Default value:
+
+```vim
+let g:BufSelectFloatWinHighlight = ''
+```
+
+For example, use same background like normal buffer for some colorschemes that don't define `NormalFloat` highlight group:
+
+```vim
+let g:BufSelectFloatWinHighlight = 'NormalFloat:Normal'
+```
+
+For more details, please check `:h 'winhl'`

--- a/autoload/bufselect.vim
+++ b/autoload/bufselect.vim
@@ -46,6 +46,9 @@ function! s:OpenBufSelectWindow(width, height)   " {{{1
                 \ 'style': 'minimal',
                 \ }, g:BufSelectFloatWinConfig)
     let s:bufSelectWindow = nvim_open_win(nvim_create_buf(0,1),1,config)
+    if strlen(g:BufSelectFloatWinHighlight)
+        call nvim_win_set_option(s:bufSelectWindow, 'winhl', g:BufSelectFloatWinHighlight)
+    endif
     setlocal syntax=bufselect nowrap bufhidden=wipe cursorline scrolloff=20
     let s:bufnrSearch = 0
 endfunction

--- a/plugin/bufselect.vim
+++ b/plugin/bufselect.vim
@@ -18,5 +18,6 @@ let g:BufSelectKeyChDirUp       = get(g:,'BufSelectKeyChDirUp',      '..')
 let g:BufSelectKeySelectOpen    = get(g:,'BufSelectKeySelectOpen',   '#')
 let g:BufSelectSortOrder        = get(g:,'BufSelectSortOrder',       'Name')
 let g:BufSelectFloatWinConfig   = get(g:, 'BufSelectFloatWinConfig', {})
+let g:BufSelectFloatWinHighlight = get(g:, 'BufSelectFloatWinHighlight', '')
 
 command! ShowBufferList :call bufselect#RefreshBufferList(-1)


### PR DESCRIPTION
Hi @PhilRunninger 

I'm adding `g:BufSelectFloatWinHighlight` option to allow to customize `winhl` for Float Window. Also, default background for BufSelect is not matching with normal buffer, I update it to match with normal buffer.

Before this PR, when starting BufSelect, it looks like:

![image](https://github.com/PhilRunninger/bufselect/assets/438791/30cc05c3-b7da-418b-837e-60492133bae4)

After this PR, it will look like:

![image](https://github.com/PhilRunninger/bufselect/assets/438791/63bdb0e3-9a62-4af6-b83a-f0edcc84770e)

Please help to review and merge it. Or if you need to update something please let me know. Thanks.