### PR TITLE
Show float window in relative to 'editor' instead of 'win'

### DIFF
--- a/autoload/bufselect.vim
+++ b/autoload/bufselect.vim
@@ -33,10 +33,10 @@ endfunction
 
 function! s:OpenBufSelectWindow(width, height)   " {{{1
     call s:ExitBufSelect()
-    let hostWidth = nvim_win_get_width(0)
-    let hostHeight = nvim_win_get_height(0)
+    let hostWidth = &columns
+    let hostHeight = &lines - &cmdheight - 1
     let config = extend({
-                \ 'relative': 'win',
+                \ 'relative': 'editor',
                 \ 'row': (hostHeight - a:height) / 2,
                 \ 'col': (hostWidth - a:width) / 2,
                 \ 'height': a:height,


### PR DESCRIPTION
Hi,

I'm not sure if this is a bug or not. When I open buffer in split/vsplit, float window displays in relative to 'win', like these

<img width="1512" alt="image" src="https://github.com/PhilRunninger/bufselect/assets/438791/1d79eeb7-cf2b-4ba2-8ff7-348872544fe9">

<img width="1512" alt="image" src="https://github.com/PhilRunninger/bufselect/assets/438791/d155f69d-44e5-4f4e-acbe-93a90d50e613">

Maybe, float window displays in relative to 'editor' like this is better?

<img width="1512" alt="image" src="https://github.com/PhilRunninger/bufselect/assets/438791/0ed4d31f-3fef-4842-9afd-434cdb51cb07">

Please help to check this PR, thanks.
